### PR TITLE
Add missing translations in templates

### DIFF
--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -12,6 +12,10 @@
   other = "Categories"
 [category]
   other = "Category"
+[tags]
+  other = "Tags"
+[tag]
+  other = "Tag"  
 [uncategorized]
   other = "Uncategorized"
 [share_post]

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -34,3 +34,11 @@
   other = "Go To Homepage"
 [404_report]
   other = "Report A Problem"
+[blog]
+  other = "Blog"
+[contact]
+  other = "Contact"
+[next_page]
+  other = "Next Page"
+[previous_page]
+  other = "Previous Page"

--- a/i18n/fr.toml
+++ b/i18n/fr.toml
@@ -34,3 +34,11 @@
   other = "Go To Homepage"
 [404_report]
   other = "Report A Problem"
+[blog]
+  other = "Blog"
+[contact]
+  other = "Contact"
+[next_page]
+  other = "Page suivante"
+[previous_page]
+  other = "Page précédente"

--- a/i18n/fr.toml
+++ b/i18n/fr.toml
@@ -12,6 +12,10 @@
   other = "Catégories"
 [category]
   other = "Catégorie"
+[tags]
+  other = "Tags"
+[tag]
+  other = "Tag"
 [uncategorized]
   other = "Sans catégorie"
 [share_post]

--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -3,9 +3,13 @@
     {{ if .IsHome }}
       <h1><a href="{{ "/" | relLangURL }}">{{ .Site.Params.navbarTitle }}</a></h1>
     {{ else if ne .Section "" }}
-      <h1><a href="{{ "/" | relLangURL }}">{{ .Section }}</a></h1>
-    {{ else }}
-      <h1><a href="{{ "/" | relLangURL }}">{{ .Title }}</a></h1>
+      {{ if i18n .Section }} 
+        <h1><a href="{{ "/" | relLangURL }}">{{ i18n .Section }}</a></h1>
+      {{ else }}
+        <h1><a href="{{ "/" | relLangURL }}">{{ .Section }}</a></h1>
+      {{ end }}
+    {{ else }} 
+        <h1><a href="{{ "/" | relLangURL }}">{{ .Title }}</a></h1>
     {{ end }}
 
     <nav class="links">

--- a/layouts/partials/pagination.html
+++ b/layouts/partials/pagination.html
@@ -2,15 +2,17 @@
 <ul class="actions pagination">
     {{ if .Paginator.HasPrev }}
         <li><a href="{{ .Paginator.Prev.URL }}"
-                class="button big previous">Previous Page</a></li>
+           class="button big previous">{{ i18n "previous_page" }}</a></li>
     {{ else }}
-        <li><a href="#" class="disabled button big previous">Previous Page</a></li>
+        <li><a href="#" 
+           class="disabled button big previous">{{ i18n "previous_page"}}</a></li>
     {{ end }}
 
     {{ if .Paginator.HasNext }}
         <li><a href="{{ .Paginator.Next.URL }}"
-                class="button big next">Next Page</a></li>
+           class="button big next">{{ i18n "next_page" }}</a></li>
     {{ else }}
-        <li><a href="#" class="disabled button big next">Next Page</a></li>
+        <li><a href="#" 
+            class="disabled button big next">{{ i18n "next_page" }}</a></li>
     {{ end }}
 </ul>

--- a/layouts/taxonomy/category.terms.html
+++ b/layouts/taxonomy/category.terms.html
@@ -12,7 +12,7 @@
 
         <ul class="posts">
             <header>
-                <h1>{{ .Data.Plural }}</h1>
+                <h1>{{ i18n .Data.Plural }}</h1>
             </header>
             {{ $data := .Data }}
             {{ range $key, $value := $.Scratch.Get "categories" }}


### PR DESCRIPTION
Some titles and buttons where not translated: 
Add pagination translations
Add navBar dynamic titles translations:
  * taxonomies need a i18n translation for display
  * terms do not need a translation because this will be should be
    already translated in the markdown files:
Add translations to category taxonimy templates